### PR TITLE
Add GitHub Skills Activity - Fix Missing Registration Option

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub. Part of our GitHub Certifications program to help with college applications.",
+        "schedule": "Wednesdays, 3:30 PM - 4:30 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Summary
This PR addresses Issue #6 by adding the missing "GitHub Skills" activity that was announced by the principal but wasn't available for student registration.

## Changes Made
- ✅ Added "GitHub Skills" activity to the activities database in `src/app.py`
- ✅ Included description highlighting the GitHub Certifications program
- ✅ Set reasonable capacity (25 students) to meet high demand
- ✅ Scheduled for Wednesdays 3:30-4:30 PM to avoid scheduling conflicts

## Issue Details
As reported by 11th grader Hewbie C., students were unable to find the GitHub Skills activity on the signup page despite the principal's announcement. This was time-sensitive as registration was supposed to close by the end of the week.

## Testing
- ✅ Python syntax validation passed
- ✅ Activity structure follows existing pattern
- ✅ No breaking changes to existing functionality

## Closes
Closes #6

## Additional Context
This activity is part of the school's new partnership with GitHub to teach practical coding and collaboration skills, helping students with their college applications through the GitHub Certifications program.